### PR TITLE
[GD-2368] Disable payment gateway when event is not active

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "givesource",
-  "version": "4.2.20",
+  "version": "4.2.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "givesource",
-      "version": "4.2.20",
+      "version": "4.2.21",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "givesource",
-  "version": "4.2.20",
+  "version": "4.2.21",
   "description": "Pay-as-you-go highly scalable software application that helps community foundations set up and manage a platform where they can raise funds for non-profits through event pages.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/frontend/src/public-pages/components/cart/Cart.vue
+++ b/packages/frontend/src/public-pages/components/cart/Cart.vue
@@ -803,7 +803,9 @@ export default {
           vm.$router.push({ name: 'cart-response' })
         }
       }).catch(err => {
-        vm.apiError = err.response.data.errors
+        vm.apiError = (err.response && err.response.data && err.response.data.errors)
+          ? err.response.data.errors
+          : { message: err.message || 'There was an error processing your payment.' }
         vm.processing = false
       })
     },

--- a/packages/frontend/src/public-pages/components/cart/Cart.vue
+++ b/packages/frontend/src/public-pages/components/cart/Cart.vue
@@ -596,7 +596,7 @@ export default {
       return this.store.setting('RECAPTCHA_KEY')
     },
     isEventOver () {
-      return Settings.isAfterEvent()
+      return Settings.isAfterDonations()
     }
   },
   watch: {
@@ -741,7 +741,7 @@ export default {
 
       vm.processing = true
 
-      if (Settings.isAfterEvent()) {
+      if (Settings.isAfterDonations()) {
         vm.apiError = { message: 'This event has ended. Donations are no longer being accepted.' }
         vm.processing = false
         return

--- a/packages/frontend/src/public-pages/components/cart/Cart.vue
+++ b/packages/frontend/src/public-pages/components/cart/Cart.vue
@@ -40,7 +40,14 @@
             @has-error="donationHasErrors"
           />
 
-          <fieldset v-if="!isCartEmpty">
+          <div
+            v-if="isEventOver"
+            class="notes notes--error"
+          >
+            This event has ended. Donations are no longer being accepted.
+          </div>
+
+          <fieldset v-if="!isCartEmpty && !isEventOver">
             <legend>
               <h2>Your Contact & Billing Info</h2>
             </legend>
@@ -283,7 +290,7 @@
             </div>
           </fieldset>
 
-          <fieldset v-if="!isCartEmpty">
+          <fieldset v-if="!isCartEmpty && !isEventOver">
             <legend>
               <h2>Your Payment Info</h2>
             </legend>
@@ -417,7 +424,7 @@
           />
 
           <div
-            v-if="!isCartEmpty"
+            v-if="!isCartEmpty && !isEventOver"
             class="form-actions flex justify-center items-center"
           >
             <VueRecaptcha
@@ -587,6 +594,9 @@ export default {
        */
     getSiteKey () {
       return this.store.setting('RECAPTCHA_KEY')
+    },
+    isEventOver () {
+      return Settings.isAfterEvent()
     }
   },
   watch: {
@@ -731,6 +741,12 @@ export default {
 
       vm.processing = true
 
+      if (Settings.isAfterEvent()) {
+        vm.apiError = { message: 'This event has ended. Donations are no longer being accepted.' }
+        vm.processing = false
+        return
+      }
+
       if (vm.getDonationTotal() < 1000) {
         vm.apiError = { message: 'The total of your donations must be at least $10.00 to process your cart.' }
         $('table.table-donations')[0].scrollIntoView(true)
@@ -830,17 +846,21 @@ export default {
         const publicApiKey = _.find(vm.settings, { key: 'PAYMENT_SPRING_PUBLIC_API_KEY' })
         const testPublicApiKey = _.find(vm.settings, { key: 'PAYMENT_SPRING_TEST_PUBLIC_API_KEY' })
 
-        if (paymentMode && paymentMode.value === '1' && publicApiKey.value) {
+        if (paymentMode && paymentMode.value === '1' && publicApiKey && publicApiKey.value) {
           return Promise.resolve(publicApiKey.value)
         }
 
-        if (paymentMode && paymentMode.value === '0' && testPublicApiKey.value) {
+        if (paymentMode && paymentMode.value === '0' && testPublicApiKey && testPublicApiKey.value) {
           return Promise.resolve(testPublicApiKey.value)
         }
 
         return Promise.reject(new Error('There was an error processing your payment.'))
       }).catch(err => {
-        vm.apiError = err.response.data.errors
+        const message = (err.response && err.response.data && err.response.data.errors)
+          ? err.response.data.errors
+          : { message: err.message || 'There was an error processing your payment.' }
+        vm.apiError = message
+        return Promise.reject(err)
       })
     },
     getPaymentToken () {

--- a/packages/frontend/src/public-pages/helpers/settings.js
+++ b/packages/frontend/src/public-pages/helpers/settings.js
@@ -272,6 +272,22 @@ const isDuringDonations = function () {
 }
 
 /**
+ * Is it after the donations end date?
+ *
+ * @returns {boolean}
+ */
+const isAfterDonations = function () {
+  const end = donationsEndDate()
+
+  if (end) {
+    const now = dayjs()
+    return now.isAfter(end, 'day')
+  }
+
+  return false
+}
+
+/**
  * Get an object representing a countdown until a certain date
  *
  * @param {Object} date
@@ -302,6 +318,7 @@ export {
   eventEndDate,
   eventStartDate,
   eventTitle,
+  isAfterDonations,
   isAfterEvent,
   isAfterRegistrations,
   isBeforeEvent,

--- a/packages/lambda/src/api/processDonations/index.js
+++ b/packages/lambda/src/api/processDonations/index.js
@@ -158,23 +158,20 @@ exports.handle = function handle (event, context, callback) {
     })
   }).then((popPT) => {
     paymentTransaction = popPT
-    return !payment.is_test_mode ? paymentTransactionsRepository.upsert(paymentTransaction, {}) : Promise.resolve(paymentTransaction)
-    // return paymentTransactionsRepository.upsert(paymentTransaction, {}); // uncomment this for testing ease
+    return paymentTransactionsRepository.upsert(paymentTransaction, {})
   }).then((response) => {
     paymentTransaction = response
     paymentTransaction.timezone = settings.EVENT_TIMEZONE
     donations.forEach((donation) => {
-      donation.paymentTransactionId = !payment.is_test_mode ? response.id : 0
+      donation.paymentTransactionId = response.id
       donation.paymentTransactionAmount = response.transactionAmount
       donation.paymentTransactionIsTestMode = response.isTestMode
       donation.paymentTransactionStatus = response.transactionStatus
     })
   }).then(function () {
-    return !payment.is_test_mode ? donorsRepository.upsert(donor, {}) : Promise.resolve(donor)
-    // return donorsRepository.upsert(donor, {}); // uncomment this for testing ease
+    return donorsRepository.upsert(donor, {})
   }).then(function (savedDonor) {
     donor = savedDonor
-    donor.id = !payment.is_test_mode ? donor.id : 0
     let promise = Promise.resolve()
     const donationValues = []
     donations.forEach(function (donation) {


### PR DESCRIPTION
## Summary

Disables transaction processing on the public cart page when the event end date has passed. Addresses card testing activity occurring after payment keys are manually removed from the database.

**Jira:** GD-2368

## Changes

1. **Early short-circuit in `submit()`** — Checks `Settings.isAfterEvent()` before any form validation or payment processing. Returns immediately with an error message so no card data is ever transmitted to the payment gateway.

2. **Fixed `getApiKey()` null-safety** — Added null checks for `publicApiKey` and `testPublicApiKey` objects before accessing `.value`. Previously, if settings were removed entirely from the DB, `_.find()` returned `undefined` and `.value` would throw silently.

3. **Fixed `getApiKey()` catch handler** — The original catch block assumed all errors were Axios errors and accessed `err.response.data.errors`. When rejection came from `Promise.reject(new Error(...))`, this threw a TypeError that was silently swallowed, causing `getApiKey()` to resolve with `undefined` and card data to still be sent to PaymentSpring. The fix safely checks for `err.response`, falls back to `err.message` for non-Axios errors, and re-rejects so the promise chain properly stops.

4. **UI lockout when event is over** — When `isEventOver` is true: displays a "This event has ended" message, hides contact/billing info fieldset, payment info fieldset, and submit button entirely so card testers cannot enter card data.

## QA Review

### Scenario 1: Event has ended (DATE_EVENT_END is in the past)
- Add items to the cart and navigate to `/cart`
- Confirm the "This event has ended. Donations are no longer being accepted." message is displayed
- Confirm the contact/billing info section is hidden
- Confirm the payment info section is hidden
- Confirm the "Complete Your Donation" button is hidden

### Scenario 2: Event is active (during event dates)
- Verify the cart page functions normally — all form fields, payment section, and submit button are visible
- Verify a donation can be processed end-to-end successfully

### Scenario 3: Payment keys removed (event ended + keys deleted from DB)
- If somehow a form submission is triggered (e.g. via browser console), confirm an appropriate error message is shown and no request is made to PaymentSpring's API
- Check browser Network tab to confirm no calls to `api.paymentspring.com` occur

### Scenario 4: Edge case — event end date not set
- If `DATE_EVENT_END` is null/empty, `Settings.isAfterEvent()` returns false — the cart should behave normally (no false lockout)